### PR TITLE
👽️ Change queryParamModal to custom hook useQueryParamModal

### DIFF
--- a/client/src/Project/NavbarLeft/index.jsx
+++ b/client/src/Project/NavbarLeft/index.jsx
@@ -30,7 +30,7 @@ const ProjectNavbarLeft = ({ issueSearchModalOpen, issueCreateModalOpen }) => (
       <AboutTooltip
         placement="right"
         offset={{ top: -218 }}
-        renderLink={linkProps => (
+        renderLink={(linkProps) => (
           <Item {...linkProps}>
             <Icon type="help" size={25} />
             <ItemText>About</ItemText>

--- a/client/src/Project/index.jsx
+++ b/client/src/Project/index.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Routes, Route, Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import useApi from 'shared/hooks/api';
+import useQueryParamModal from 'shared/hooks/queryParamModal';
+
 import { updateArrayItemById } from 'shared/utils/javascript';
 import { createQueryParamModalHelpers } from 'shared/utils/queryParamModal';
 import { PageLoader, PageError, Modal } from 'shared/components';
@@ -12,14 +14,17 @@ import Board from './Board';
 import IssueSearch from './IssueSearch';
 import IssueCreate from './IssueCreate';
 import ProjectSettings from './ProjectSettings';
+
 import { ProjectPage } from './Styles';
 
 const Project = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const issueSearchModalHelpers = createQueryParamModalHelpers('issue-search');
-  const issueCreateModalHelpers = createQueryParamModalHelpers('issue-create');
+  // const issueSearchModalHelpers = createQueryParamModalHelpers('issue-search');
+  // const issueCreateModalHelpers = createQueryParamModalHelpers('issue-create');
+  const issueSearchModalHelpers = useQueryParamModal('issue-search');
+  const issueCreateModalHelpers = useQueryParamModal('issue-create');
 
   const [{ data, error, setLocalData }, fetchProject] = useApi.get('/project');
 

--- a/client/src/shared/components/Icon/index.jsx
+++ b/client/src/shared/components/Icon/index.jsx
@@ -54,9 +54,6 @@ const defaultProps = {
 };
 
 const Icon = ({ type, ...iconProps }) => {
-  console.log('Icon type:', type);
-  console.log('Icon code:', fontIconCodes[type]);
-  console.log('Icon code repr:', JSON.stringify(fontIconCodes[type]));
   return <StyledIcon {...iconProps} data-testid={`icon:${type}`} code={fontIconCodes[type]} />;
 };
 

--- a/client/src/shared/hooks/queryParamModal.js
+++ b/client/src/shared/hooks/queryParamModal.js
@@ -1,0 +1,29 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+import { queryStringToObject, addToQueryString, omitFromQueryString } from 'shared/utils/url';
+
+const useQueryParamModal = (param) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const open = () => {
+    const pathname = location.pathname;
+    const search = addToQueryString(location.search, { [`modal-${param}`]: true });
+    // console.log('pathName: ', pathname);
+    // console.log('search: ', search);
+    navigate({ pathname, search });
+  };
+
+  const close = () => {
+    const pathname = location.pathname;
+    const search = omitFromQueryString(location.search, [`modal-${param}`]);
+    // console.log('pathName: ', pathname);
+    // console.log('search: ', search);
+    navigate({ pathname, search });
+  };
+
+  const isOpen = () => !!queryStringToObject(location.search)[`modal-${param}`];
+
+  return { open, close, isOpen };
+};
+
+export default useQueryParamModal;

--- a/client/src/shared/utils/queryParamModal.js
+++ b/client/src/shared/utils/queryParamModal.js
@@ -1,21 +1,26 @@
 import history from 'browserHistory';
+
 import { queryStringToObject, addToQueryString, omitFromQueryString } from 'shared/utils/url';
 
-const open = param =>
+const open = (param) => {
   history.push({
     pathname: history.location.pathname,
     search: addToQueryString(history.location.search, { [`modal-${param}`]: true }),
   });
 
-const close = param =>
+  //pathname: /project/board,
+  //search: ?modal-issue-create=true
+};
+
+const close = (param) =>
   history.push({
     pathname: history.location.pathname,
     search: omitFromQueryString(history.location.search, [`modal-${param}`]),
   });
 
-const isOpen = param => !!queryStringToObject(history.location.search)[`modal-${param}`];
+const isOpen = (param) => !!queryStringToObject(history.location.search)[`modal-${param}`];
 
-export const createQueryParamModalHelpers = param => ({
+export const createQueryParamModalHelpers = (param) => ({
   open: () => open(param),
   close: () => close(param),
   isOpen: () => isOpen(param),


### PR DESCRIPTION
Replace deprecated React Router browserHistory API with useNavigate and useLocation. New API requried custom hook.